### PR TITLE
Use `getPlayerExact()` instead of `getPlayerByPrefix`

### DIFF
--- a/src/r3pt1s/GroupSystem/player/GroupPlayer.php
+++ b/src/r3pt1s/GroupSystem/player/GroupPlayer.php
@@ -72,6 +72,6 @@ class GroupPlayer {
     }
 
     public function getPlayer(): ?Player {
-        return Server::getInstance()->getPlayerByPrefix($this->name);
+        return Server::getInstance()->getPlayerExact($this->name);
     }
 }


### PR DESCRIPTION
`Server::getPlayerByPrefix()` is autocompleting names but `Server::getPlayerExact()` only get a player if a player with that name is online.